### PR TITLE
Add dates and info to sign up page and add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Women Who Code Austin
+
+## Contributing
+Setup is easy! No need to run a server. Simply edit the markdown files.
+
+* Learn markdown [here](https://guides.github.com/features/mastering-markdown/)
+* Render markdown locally without a server
+  * in your browser with [a chrome extension](https://chrome.google.com/webstore/detail/markdown-preview-plus/febilkbfcbhebfnokafefeacimjdckgl?hl=en-US)
+  * in Atom with [this package](https://atom.io/packages/markdown-preview-plus)

--- a/content/hackathon/signup.md
+++ b/content/hackathon/signup.md
@@ -1,9 +1,24 @@
 ---
-title: "6th ATX Diversity Sign up"
+title: "Women Who Code Austin 6th Annual Diversity Hackathon Sign up"
 date: 2020-08-30T13:00:00-05:00
 draft: false
 ---
 
-Join Women Who Code Austin for our 6th annual diversity hackathon. This is a virtual hackathon, with online workshops. Please sign up [here](https://www.eventbrite.com/e/6th-annual-austin-diversity-hackathon-atxdivhack-registration-115101774506)
+Join Women Who Code Austin (ATX) for our 6th annual Diversity Hackathon. This is a virtual hackathon, with online workshops.
 
+**When:** Fri, Sep 18, 2020, 9:00 AM – Sun, Sep 20, 2020, 5:00 PM CDT
 
+**Registration:** [sign up here](https://www.eventbrite.com/e/6th-annual-austin-diversity-hackathon-atxdivhack-registration-115101774506)
+
+This hackathon is a celebration of diversity. Anyone who supports diversity is welcome — no matter your level of technical knowledge.
+
+We are providing a virtual space for people of all backgrounds who want to start building their tech portfolio or finish up a tech project while learning new skills. Previous experience in tech is **NOT** required.
+
+Plus, we have a parallel [FREE workshop track](http://wwcodeatx.github.io/hackathon/workshops/) for anyone who wants to come and just start learning, learn more, or meet people.
+
+Once you sign up, we will provide you a link to pitch your hackathon idea/see other people's idea, and slack channel sign up link. [See hackathon judging criteria](http://wwcodeatx.github.io/hackathon/hackathon-rules/).
+
+Not sure what to work on? We encourage participants to look into open data or civic hacking projects, for more information check out [Open Austin](https://www.open-austin.org/about/). Check [past blog posts](https://siliconion.github.io/post/what-to-make-at-atx-diversity-hackathon/) for ideas.
+
+### Interested in mentoring the participants?
+Please [fill out this form](https://forms.gle/ZqGrXBTGNiQzjxGYA) and we will contact you shortly!


### PR DESCRIPTION
I was sharing the site with women at work today and discovered that we don't mention the hackathon dates on the main signup page. I also thought it would be helpful to have more event info on that page as well, so I copied it from the Eventbrite page.

Screenshot of markdown rendered locally:
<img width="765" alt="Screen Shot 2020-09-04 at 3 33 48 PM" src="https://user-images.githubusercontent.com/8680712/92282950-58db7700-eec4-11ea-9465-46de206ce851.png">


I also added a README for the repo to make it easier for people to contribute. Screenshot of markdown rendered locally: 
<img width="447" alt="Screen Shot 2020-09-04 at 3 34 05 PM" src="https://user-images.githubusercontent.com/8680712/92282937-54af5980-eec4-11ea-9faf-54a431f5d031.png">
